### PR TITLE
Add publisher for wheel joints.

### DIFF
--- a/grizzly_description/urdf/base.urdf.xacro
+++ b/grizzly_description/urdf/base.urdf.xacro
@@ -180,15 +180,15 @@ This program contains the description of the robot base model for the Clearpath 
     <material>Gazebo/Yellow</material>
   </gazebo>
 
-  <!-- Back wheels -->
-  <grizzly_wheel fb="back"
+  <!-- rear wheels -->
+  <grizzly_wheel fr="rear"
                  lr="left"
                  parent="base_link"
                  translateX="-1.75"
                  translateY="1.75"
                  translateZ="0"
                  flipY="0" />
-  <grizzly_wheel fb="back"
+  <grizzly_wheel fr="rear"
                  lr="right"
                  parent="base_link"
                  translateX="-1.75"
@@ -246,14 +246,14 @@ This program contains the description of the robot base model for the Clearpath 
   </gazebo>
 
   <!-- Front wheels -->
-  <grizzly_wheel fb="front"
+  <grizzly_wheel fr="front"
                  lr="left"
                  parent="front_axle_link"
                  translateX="0"
                  translateY="1.75"
                  translateZ="0"
                  flipY="0" />
-  <grizzly_wheel fb="front"
+  <grizzly_wheel fr="front"
                  lr="right"
                  parent="front_axle_link"
                  translateX="0"
@@ -267,8 +267,8 @@ This program contains the description of the robot base model for the Clearpath 
             filename="libgrizzly_gazebo_plugins.so">
       <alwaysOn>true</alwaysOn>
       <updateRate>100.0</updateRate>
-      <backLeftJoint>joint_back_left_wheel</backLeftJoint>
-      <backRightJoint>joint_back_right_wheel</backRightJoint>
+      <rearLeftJoint>joint_rear_left_wheel</rearLeftJoint>
+      <rearRightJoint>joint_rear_right_wheel</rearRightJoint>
       <frontLeftJoint>joint_front_left_wheel</frontLeftJoint>
       <frontRightJoint>joint_front_right_wheel</frontRightJoint>
       <frontAxleJoint>front_axle_joint</frontAxleJoint>

--- a/grizzly_description/urdf/wheel.urdf.xacro
+++ b/grizzly_description/urdf/wheel.urdf.xacro
@@ -81,9 +81,9 @@ This program contains the description of the robot wheel model for Clearpath Gri
             value="0.2" />
   <!-- origin is offset in + z direction by 3.175mm, so need to bring it back down for visual and collision-->
   <xacro:macro name="grizzly_wheel"
-               params="fb lr parent translateX translateY translateZ flipY">
-    <!--fb : front, back ; lr: left, right -->
-    <link name="${fb}_${lr}_wheel">
+               params="fr lr parent translateX translateY translateZ flipY">
+    <!--fr : front, rear ; lr: left, right -->
+    <link name="${fr}_${lr}_wheel">
       <inertial>
         <mass value="${wheel_mass}" />
         <origin xyz="${wheel_x_com} ${wheel_y_com} ${wheel_z_com}" />
@@ -111,7 +111,7 @@ This program contains the description of the robot wheel model for Clearpath Gri
         </geometry>
       </collision>
     </link>
-    <gazebo reference="${fb}_${lr}_wheel">
+    <gazebo reference="${fr}_${lr}_wheel">
       <mu1 value="100.0" />
       <mu2 value="0.1" />
       <kp value="10000000.0" />
@@ -121,10 +121,10 @@ This program contains the description of the robot wheel model for Clearpath Gri
       <turnGravityOff>false</turnGravityOff>
       <selfCollide>true</selfCollide>
     </gazebo>
-    <joint name="joint_${fb}_${lr}_wheel"
+    <joint name="joint_${fr}_${lr}_wheel"
            type="continuous">
       <parent link="${parent}" />
-      <child link="${fb}_${lr}_wheel" />
+      <child link="${fr}_${lr}_wheel" />
       <origin xyz="${translateX * base_x_origin_to_wheel_origin} ${translateY * base_y_origin_to_wheel_origin} ${translateZ}"
               rpy="0 0 0" />
       <axis xyz="0 1 0"
@@ -135,10 +135,10 @@ This program contains the description of the robot wheel model for Clearpath Gri
                         friction="0.0" />
     </joint>
     <!-- Transmission is important to link the joints and the controller -->
-    <transmission name="joint_${fb}_${lr}_wheel_trans"
+    <transmission name="joint_${fr}_${lr}_wheel_trans"
                   type="SimpleTransmission">
-      <actuator name="joint_${fb}_${lr}_wheel_motor" />
-      <joint name="joint_${fb}_${lr}_wheel" />
+      <actuator name="joint_${fr}_${lr}_wheel_motor" />
+      <joint name="joint_${fr}_${lr}_wheel" />
       <mechanicalReduction>1</mechanicalReduction>
       <motorTorqueConstant>1</motorTorqueConstant>
     </transmission>

--- a/grizzly_motion/CMakeLists.txt
+++ b/grizzly_motion/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(grizzly_motion)
 
-find_package(catkin REQUIRED COMPONENTS cmake_modules geometry_msgs grizzly_msgs roboteq_msgs roscpp tf diagnostic_updater)
+find_package(catkin REQUIRED COMPONENTS cmake_modules geometry_msgs grizzly_msgs roboteq_msgs roscpp tf diagnostic_updater angles)
 find_package(Eigen REQUIRED)
 
 catkin_package(

--- a/grizzly_motion/include/grizzly_motion/dead_reckoning.h
+++ b/grizzly_motion/include/grizzly_motion/dead_reckoning.h
@@ -85,7 +85,6 @@ protected:
   std::vector<std::string> joint_name_;
   std::vector<double> joint_pos_;
   std::vector<double> joint_vel_;
-  std::vector<>double joint_eff_;
   std::vector<double> last_joint_pos_;
 
   // Configuration

--- a/grizzly_motion/include/grizzly_motion/dead_reckoning.h
+++ b/grizzly_motion/include/grizzly_motion/dead_reckoning.h
@@ -25,6 +25,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "nav_msgs/Odometry.h"
 #include "grizzly_msgs/Drive.h"
+#include <grizzly_msgs/eigen.h>
 #include "sensor_msgs/JointState.h"
 
 #include <Eigen/Core>
@@ -82,9 +83,6 @@ protected:
   geometry_msgs::Twist twist_; 
   double yaw_;
   bool initialize;
-  std::vector<std::string> joint_name_;
-  std::vector<double> joint_pos_;
-  std::vector<double> joint_vel_;
   std::vector<double> last_joint_pos_;
 
   // Configuration

--- a/grizzly_motion/include/grizzly_motion/dead_reckoning.h
+++ b/grizzly_motion/include/grizzly_motion/dead_reckoning.h
@@ -25,6 +25,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "nav_msgs/Odometry.h"
 #include "grizzly_msgs/Drive.h"
+#include "sensor_msgs/JointState.h"
 
 #include <Eigen/Core>
 #include <Eigen/Dense>
@@ -66,11 +67,11 @@ class DeadReckoning
 {
 public:
   DeadReckoning(double vehicle_width, double wheel_radius) 
-  : max_dt_(0.1), width_(vehicle_width), radius_(wheel_radius)
+  : max_dt_(0.1), width_(vehicle_width), radius_(wheel_radius), initialize(false)
   {
   }
 
-  bool next(const grizzly_msgs::DriveConstPtr& encoders, nav_msgs::Odometry* odom);
+  bool next(const grizzly_msgs::DriveConstPtr& encoders, nav_msgs::Odometry* odom, sensor_msgs::JointState* joints);
  
 protected:
   // Maintaining state between encoder updates.
@@ -80,6 +81,12 @@ protected:
   geometry_msgs::Point position_; 
   geometry_msgs::Twist twist_; 
   double yaw_;
+  bool initialize;
+  std::vector<std::string> joint_name_;
+  std::vector<double> joint_pos_;
+  std::vector<double> joint_vel_;
+  std::vector<>double joint_eff_;
+  std::vector<double> last_joint_pos_;
 
   // Configuration
   double width_, radius_;

--- a/grizzly_motion/package.xml
+++ b/grizzly_motion/package.xml
@@ -18,6 +18,8 @@
   <build_depend>roboteq_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>angles</build_depend>
+  <run_depend>angles</run_depend>
   <run_depend>diagnostic_updater</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>grizzly_msgs</run_depend>


### PR DESCRIPTION
- In the dead_rockening node, wheel joint states are computed from encoder data and published on `joint_states` topic. 
- fixes https://github.com/g/grizzly/issues/2
