### PR TITLE
add front axle publisher.

### DIFF
--- a/grizzly_motion/src/dead_reckoning.cpp
+++ b/grizzly_motion/src/dead_reckoning.cpp
@@ -41,9 +41,10 @@ bool DeadReckoning::next(const grizzly_msgs::DriveConstPtr& encoders, nav_msgs::
   bool success = false;
   VectorDrive wheels_speed_ = grizzly_msgs::vectorFromDriveMsg(*encoders);
   uint8_t wheels_num_ = wheels_speed_.size();
+  uint8_t joints_num_ = wheels_num_ + 1; // add front_axle_joint
 
   if(!initialize) { 
-    last_joint_pos_.resize(wheels_num_, 0.0); 
+    last_joint_pos_.resize(joints_num_, 0.0); 
     last_time_ = encoders->header.stamp; 
     yaw_ = 0.0;  
     initialize = true;
@@ -55,12 +56,16 @@ bool DeadReckoning::next(const grizzly_msgs::DriveConstPtr& encoders, nav_msgs::
                          (encoders->front_right + encoders->rear_right) / 2);
   Vector2f vels = avg_rotations * radius_;
 
-  joints->position.resize(wheels_num_, 0.0);
+  joints->position.resize(joints_num_, 0.0);
+  joints->effort.resize(joints_num_,0);
 
   for(uint8_t i = 0; i < wheels_num_; i++){
     joints->velocity.push_back(wheels_speed_[i]);
-    joints->name.push_back(grizzly_msgs::nameFromDriveIndex(i));
+    joints->name.push_back("joint_"+grizzly_msgs::nameFromDriveIndex(i)+"_wheel");
   }
+  joints->velocity.push_back(0);
+  joints->name.push_back("front_axle_joint");
+
 
   ros::Duration dt = encoders->header.stamp - last_time_;
 

--- a/grizzly_msgs/include/grizzly_msgs/eigen.h
+++ b/grizzly_msgs/include/grizzly_msgs/eigen.h
@@ -75,10 +75,10 @@ static inline std::string nameFromDriveIndex(VectorDrive::Index field)
 {
   switch(field)
   {
-    case Drives::FrontLeft: return "front-left";
-    case Drives::FrontRight: return "front-right";
-    case Drives::RearLeft: return "rear-left";
-    case Drives::RearRight: return "rear-right";
+    case Drives::FrontLeft: return "front_left";
+    case Drives::FrontRight: return "front_right";
+    case Drives::RearLeft: return "rear_left";
+    case Drives::RearRight: return "rear_right";
     default:
       throw std::out_of_range("Passed field number not in range 0..3");
   }


### PR DESCRIPTION
- add front axle publisher. It publishes 0.0, 0.0, 0.0 for position, velocity and effort.
- change wheel names in nameFromDriveIndex function to match with joint names in URDF (e.g. from front-left to front_left)
