### PR TITLE
Transition out of Moving state when Estopped

### DIFF
--- a/grizzly_motion/src/motion_safety_node.cpp
+++ b/grizzly_motion/src/motion_safety_node.cpp
@@ -173,6 +173,8 @@ void MotionSafety::watchdogCallback(const ros::TimerEvent&)
       grizzly_msgs::Ambience::PATTERN_FLASH;
     if (!encoders_ok)
       setStop("Encoders not okay.", true, true);
+    if (isEstopped())
+      setStop("External estop.");
     //if (!motor_controllers_ok)
     //  setStop("Motor controllers not okay.", true);
 


### PR DESCRIPTION
...s, the state machine will get stuck in the Moving state if the vehicle is estopped while there is still a stream of motion commands being sent.
