### PR TITLE
Added a precharge check before transitioning into MOVING state. Witho…

### DIFF
--- a/grizzly_motion/src/motion_safety_node.cpp
+++ b/grizzly_motion/src/motion_safety_node.cpp
@@ -155,7 +155,7 @@ void MotionSafety::watchdogCallback(const ros::TimerEvent&)
   {
     ambience.beacon = ambience.headlight = ambience.taillight = ambience.beep =
       grizzly_msgs::Ambience::PATTERN_DFLASH;
-    if (ros::Time::now() > transition_to_moving_time_)
+    if (ros::Time::now() > transition_to_moving_time_ && !last_mcu_status_->error)
       state_ = MotionStates::Moving;
     if (ros::Time::now() - last_commanded_movement_time_ > ros::Duration(0.1))
       setStop("Command messages stale.");


### PR DESCRIPTION
Grizzly exhibits stuttering when transitioning from Stopped to Moving while a constant cmd_vel is being streamed to it. This is because the state machine is transitioning from STARTING to MOVING before the precharge completes. 

The wait time is currently hard coded at 2.0s, but sometimes the precharge can take longer. This PR adds a check to ensure that the precharge has finished before the state machine transitions to MOVING.
